### PR TITLE
Update linq/s-q-o/snippets/s-q-o/ConversionExamples.cs

### DIFF
--- a/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/ConversionExamples.cs
+++ b/docs/csharp/linq/standard-query-operators/snippets/standard-query-operators/ConversionExamples.cs
@@ -17,7 +17,7 @@ public class ConversionExamples
         // <CastOperatorQuerySyntax>
         IEnumerable people = students;
 
-        var query = from Student student in students
+        var query = from Student student in people
                     where student.Year == GradeLevel.ThirdYear
                     select student;
 


### PR DESCRIPTION
Hi, regarding to the educating objective of our honorable author in this section of article and corresponding code snippet, I think the source sequence of the 'form' clause, inside the CastExampleQuery Method, should be changed to 'people'. (Currently the source sequence is 'students')

## Summary

Describe your changes here.

Fixes #Issue_Number (if available)
